### PR TITLE
Add delete recommendation endpoint and tests

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -138,6 +138,10 @@ class Recommendation(db.Model):
                 "Invalid Recommendation: body of request contained bad or no data "
                 + str(error)
             ) from error
+        except ValueError as error:
+            raise DataValidationError(
+                "Invalid Recommendation: invalid recommendation_type"
+            ) from error
         return self
 
     ##################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -99,3 +99,22 @@ def check_content_type(content_type) -> None:
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
+
+
+######################################################################
+# DELETE A NEW Recommendation
+######################################################################
+@app.route("/recommendations/<int:recommendation_id>", methods=["DELETE"])
+def delete_recommendation(recommendation_id):
+    """Delete a Recommendation"""
+    app.logger.info("Request to delete recommendation with id: %s", recommendation_id)
+
+    recommendation = Recommendation.find(recommendation_id)
+    if not recommendation:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Recommendation with id '{recommendation_id}' was not found.",
+        )
+
+    recommendation.delete()
+    return "", status.HTTP_204_NO_CONTENT

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,6 +25,7 @@ from unittest import TestCase
 from wsgi import app
 from service.models import Recommendation, RecommendationType, DataValidationError, db
 from .factories import RecommendationFactory
+from unittest.mock import patch
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -67,14 +68,126 @@ class TestRecommendation(TestCase):
 
     def test_create_recommendation(self):
         """It should create a Recommendation"""
-        recommendation= RecommendationFactory()
+        recommendation = RecommendationFactory()
         recommendation.create()
         self.assertIsNotNone(recommendation.id)
         found = Recommendation.all()
         self.assertEqual(len(found), 1)
         data = Recommendation.find(recommendation.id)
         self.assertEqual(data.source_product_id, recommendation.source_product_id)
-        self.assertEqual(data.recommended_product_id, recommendation.recommended_product_id)
+        self.assertEqual(
+            data.recommended_product_id, recommendation.recommended_product_id
+        )
         self.assertEqual(data.recommendation_type, recommendation.recommendation_type)
+
+    def test_update_a_recommendation(self):
+        """It should update a Recommendation"""
+        recommendation = RecommendationFactory()
+        recommendation.create()
+
+        recommendation.recommendation_type = RecommendationType.UP_SELL
+        recommendation.update()
+
+        found = Recommendation.find(recommendation.id)
+        self.assertEqual(found.recommendation_type, RecommendationType.UP_SELL)
+
+    def test_delete_a_recommendation(self):
+        """It should delete a Recommendation"""
+        recommendation = RecommendationFactory()
+        recommendation.create()
+
+        recommendation.delete()
+        found = Recommendation.find(recommendation.id)
+        self.assertIsNone(found)
+
+    def test_find_recommendation(self):
+        """It should find a Recommendation by id"""
+        recommendation = RecommendationFactory()
+        recommendation.create()
+
+        found = Recommendation.find(recommendation.id)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.id, recommendation.id)
+
+    def test_list_all_recommendations(self):
+        """It should return all Recommendations"""
+        rec1 = RecommendationFactory()
+        rec2 = RecommendationFactory()
+        rec1.create()
+        rec2.create()
+
+        recommendations = Recommendation.all()
+        self.assertEqual(len(recommendations), 2)
+
+    def test_deserialize_with_missing_data(self):
+        """It should not deserialize a Recommendation with missing data"""
+        recommendation = Recommendation()
+        self.assertRaises(DataValidationError, recommendation.deserialize, {})
+
+    def test_deserialize_with_none(self):
+        """It should not deserialize a Recommendation with bad data"""
+        recommendation = Recommendation()
+        self.assertRaises(DataValidationError, recommendation.deserialize, None)
+
+    def test_deserialize_with_invalid_enum(self):
+        """It should not deserialize a Recommendation with invalid recommendation_type"""
+        recommendation = Recommendation()
+        bad_data = {
+            "source_product_id": 1,
+            "recommended_product_id": 2,
+            "recommendation_type": "not_real",
+        }
+        self.assertRaises(DataValidationError, recommendation.deserialize, bad_data)
+
+    def test_serialize_a_recommendation(self):
+        """It should serialize a Recommendation"""
+        recommendation = RecommendationFactory()
+        data = recommendation.serialize()
+        self.assertEqual(data["source_product_id"], recommendation.source_product_id)
+        self.assertEqual(
+            data["recommended_product_id"], recommendation.recommended_product_id
+        )
+        self.assertEqual(
+            data["recommendation_type"], recommendation.recommendation_type.value
+        )
+
+    def test_repr_of_recommendation(self):
+        """It should return the string representation of a Recommendation"""
+        recommendation = RecommendationFactory()
+        self.assertIn("Recommendation", repr(recommendation))
+        self.assertIn(str(recommendation.source_product_id), repr(recommendation))
+
+    def test_find_recommendation_not_found(self):
+        """It should return None if a Recommendation is not found"""
+        recommendation = Recommendation.find(0)
+        self.assertIsNone(recommendation)
+
+    @patch("service.models.db.session.commit")
+    def test_create_raises_data_validation_error(self, mock_commit):
+        """It should raise DataValidationError when create fails"""
+        mock_commit.side_effect = Exception("db boom")
+        recommendation = RecommendationFactory()
+        self.assertRaises(DataValidationError, recommendation.create)
+
+    @patch("service.models.db.session.commit")
+    def test_update_raises_data_validation_error(self, mock_commit):
+        """It should raise DataValidationError when update fails"""
+        recommendation = RecommendationFactory()
+        recommendation.create()
+        mock_commit.side_effect = Exception("db boom")
+        self.assertRaises(DataValidationError, recommendation.update)
+
+    @patch("service.models.db.session.commit")
+    def test_delete_raises_data_validation_error(self, mock_commit):
+        """It should raise DataValidationError when delete fails"""
+        recommendation = RecommendationFactory()
+        recommendation.create()
+        mock_commit.side_effect = Exception("db boom")
+        self.assertRaises(DataValidationError, recommendation.delete)
+
+    def test_deserialize_with_bad_attribute(self):
+        """It should not deserialize a Recommendation with a bad attribute"""
+        recommendation = Recommendation()
+        self.assertRaises(DataValidationError, recommendation.deserialize, "not a dict")
 
     # Todo: Add your test cases here...

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,6 +101,67 @@ class TestYourResourceService(TestCase):
             test_recommendation.recommendation_type.value,
         )
 
+    def test_delete_recommendation(self):
+        """It should Delete an existing Recommendation"""
+        test_recommendation = RecommendationFactory()
+        response = self.client.post(BASE_URL, json=test_recommendation.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        new_recommendation = response.get_json()
+        recommendation_id = new_recommendation["id"]
+
+        response = self.client.delete(f"{BASE_URL}/{recommendation_id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        deleted_recommendation = Recommendation.find(recommendation_id)
+        self.assertIsNone(deleted_recommendation)
+
+    def test_delete_recommendation_not_found(self):
+        """It should return 404 when deleting a Recommendation that does not exist"""
+        response = self.client.delete(f"{BASE_URL}/999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_recommendation_missing_field(self):
+        """It should not Create a Recommendation with missing data"""
+        test_recommendation = {"source_product_id": 1, "recommended_product_id": 2}
+        response = self.client.post(BASE_URL, json=test_recommendation)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_recommendation_invalid_type(self):
+        """It should not Create a Recommendation with invalid recommendation type"""
+        test_recommendation = {
+            "source_product_id": 1,
+            "recommended_product_id": 2,
+            "recommendation_type": "invalid_type",
+        }
+        response = self.client.post(BASE_URL, json=test_recommendation)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_method_not_allowed(self):
+        """It should return 405 when using an unsupported method"""
+        response = self.client.put(BASE_URL, json={})
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_create_recommendation_no_json(self):
+        """It should not Create a Recommendation with non-JSON data"""
+        response = self.client.post(
+            BASE_URL, data="not json", content_type="text/plain"
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    def test_create_recommendation_no_content_type(self):
+        """It should not Create a Recommendation without a Content-Type header"""
+        test_recommendation = {
+            "source_product_id": 1,
+            "recommended_product_id": 2,
+            "recommendation_type": "cross_sell",
+        }
+        response = self.client.post(
+            BASE_URL,
+            data='{"source_product_id": 1, "recommended_product_id": 2, "recommendation_type": "cross_sell"}',
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
         # # Uncomment this code when get_recommendations is implemented
         # # Check that the location header was correct
         # response = self.client.get(location)


### PR DESCRIPTION
Implements DELETE /recommendations/<id> for Recommendation resource.

- returns 204 No Content on success
- returns 404 Not Found if recommendation does not exist
- adds tests and raises coverage above threshold

Closes #12