### PR TITLE
Update root URL to return service metadata

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -34,7 +34,15 @@ from service.common import status  # HTTP Status Codes
 def index():
     """Root URL response"""
     return (
-        "Reminder: return some useful information in json format about the service here",
+        jsonify(
+            {
+                "name": "Recommendation REST API Service",
+                "version": "1.0.0",
+                "paths": {
+                    "list": "/recommendations",
+                },
+            }
+        ),
         status.HTTP_200_OK,
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -71,9 +71,15 @@ class TestYourResourceService(TestCase):
     ######################################################################
 
     def test_index(self):
-        """It should call the home page"""
+        """It should call the home page and return service metadata"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        data = resp.get_json()
+        self.assertIsNotNone(data)
+        self.assertEqual(data["name"], "Recommendation REST API Service")
+        self.assertEqual(data["version"], "1.0.0")
+        self.assertEqual(data["paths"]["list"], "/recommendations")
 
     def test_create_recommendation(self):
         """It should Create a new Recommendation"""


### PR DESCRIPTION
Closes #11

- Updated root URL `/` to return JSON metadata
- Added test coverage for root URL response
- Includes service name, version, and list endpoint path