### PR TITLE
Add Kubernetes manifests for recommendations service closes #37

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendations
+  labels:
+    app: recommendations
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendations
+  template:
+    metadata:
+      labels:
+        app: recommendations
+    spec:
+      containers:
+        - name: recommendations
+          image: cluster-registry:5000/petshop:1.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: FLASK_RUN_PORT
+              value: "8080"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: recommendations
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /recommendations
+            pathType: Prefix
+            backend:
+              service:
+                name: recommendations
+                port:
+                  number: 8080

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendations
+  labels:
+    app: recommendations
+spec:
+  selector:
+    app: recommendations
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
- created the k8s/ folder in the project root with the three Kubernetes manifest files needed to deploy the recommendations service:
  - deployment.yaml — deploys the recommendations service using the cluster-registry:5000/petshop:1.0 image on port 8080
  - service.yaml — exposes the service internally on port 8080 via ClusterIP
  - ingress.yaml — routes external traffic from /recommendations to the service