### PR TITLE
fix: update IMAGE_NAME from petshop to recommendations in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # These can be overidden with env vars.
 REGISTRY ?= cluster-registry:5000
-IMAGE_NAME ?= petshop
+IMAGE_NAME ?= recommendations
 IMAGE_TAG ?= 1.0
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 PLATFORM ?= "linux/amd64,linux/arm64"


### PR DESCRIPTION
## Summary
Updates the IMAGE_NAME variable in the Makefile from the default `petshop` placeholder to `recommendations` so that make build, make push, and make deploy work correctly for this project.

## Changes
- Updated IMAGE_NAME from `petshop` to `recommendations`

## Testing
- [ ] make cluster creates K3S cluster successfully
- [ ] make build builds the recommendations image successfully
- [ ] make push pushes image to cluster-registry:5000
- [ ] make deploy deploys service to local Kubernetes cluster

Closes #39