### PR TITLE
fix: update deployment.yaml image name and add DATABASE_URI env var

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,9 +16,14 @@ spec:
     spec:
       containers:
         - name: recommendations
-          image: cluster-registry:5000/petshop:1.0
+          image: cluster-registry:5000/recommendations:1.0
           ports:
             - containerPort: 8080
           env:
             - name: FLASK_RUN_PORT
               value: "8080"
+            - name: DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: database_uri


### PR DESCRIPTION
## Summary
Fixes k8s/deployment.yaml to use the correct image name and adds the DATABASE_URI environment variable so the service can connect to the PostgreSQL StatefulSet.

## Changes
- Updated image from `petshop:1.0` to `recommendations:1.0`
- Added DATABASE_URI env var from postgres-creds secret

## Testing
- [ ] make cluster creates K3S cluster without errors
- [ ] make build builds the image without errors
- [ ] make push pushes the image without errors
- [ ] make deploy deploys all manifests without errors
- [ ] Ingress routes traffic to the service correctly
- [ ] All 5 REST API endpoints return correct responses
- [ ] Service connects to PostgreSQL StatefulSet correctly

Closes #40