### PR TITLE
Create UI for Recommendation - Read (#34)

### DIFF
--- a/features/recommendations.feature
+++ b/features/recommendations.feature
@@ -16,3 +16,24 @@ Feature: Recommendations Service
         Then I should see the message "Recommendation created successfully!"
         And I should see "1" in the "Source Product ID" field
         And I should see "2" in the "Recommended Product ID" field
+
+    Scenario: Read an existing Recommendation
+        When I visit the "Home Page"
+        Then I should see "Recommendations" in the title
+        When I set the "Source Product ID" to "10"
+        And I set the "Recommended Product ID" to "20"
+        And I select "Cross Sell" in the "Recommendation Type" dropdown
+        And I press the "Create" button
+        Then I should see the message "Recommendation created successfully!"
+        When I copy the "ID" field
+        And I press the "Clear" button
+        And I paste the "Read ID" field
+        And I press the "Read" button
+        Then I should see the message "Recommendation retrieved successfully!"
+
+    Scenario: Read a non-existent Recommendation returns 404
+        When I visit the "Home Page"
+        Then I should see "Recommendations" in the title
+        When I set the "Read ID" to "999999"
+        And I press the "Read" button
+        Then I should see the message "was not found"

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -74,6 +74,45 @@
         </div> <!-- end well -->
       </div> <!-- end Form -->
 
+      <!-- READ FORM -->
+      <div class="col-md-12" id="read_form">
+        <h3>Read a Recommendation:</h3>
+        <div class="well">
+          <div class="form-horizontal">
+
+            <!-- READ ID -->
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="recommendation_read_id">ID:</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="recommendation_read_id" placeholder="Enter Recommendation ID">
+              </div>
+            </div>
+
+            <!-- READ BUTTON -->
+            <div class="form-group">
+              <div class="col-sm-offset-2 col-sm-10">
+                <button type="submit" class="btn btn-info" id="read-btn">Read</button>
+              </div>
+            </div>
+
+            <!-- READ RESULTS -->
+            <div class="form-group">
+              <label class="control-label col-sm-2">Result:</label>
+              <div class="col-sm-10">
+                <p>ID: <span id="read_result_id"></span></p>
+                <p>Source Product ID: <span id="read_result_source_product_id"></span></p>
+                <p>Recommended Product ID: <span id="read_result_recommended_product_id"></span></p>
+                <p>Recommendation Type: <span id="read_result_recommendation_type"></span></p>
+                <p>Like Count: <span id="read_result_like_count"></span></p>
+                <p>Created At: <span id="read_result_created_at"></span></p>
+                <p>Updated At: <span id="read_result_updated_at"></span></p>
+              </div>
+            </div>
+
+          </div> <!-- form horizontal -->
+        </div> <!-- end well -->
+      </div> <!-- end Read Form -->
+
       <!-- Search Results -->
       <div class="table-responsive col-md-12" id="search_results">
         <table class="table table-striped">

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -8,6 +8,14 @@ $(function () {
         $("#recommendation_source_product_id").val("");
         $("#recommendation_recommended_product_id").val("");
         $("#recommendation_recommendation_type").val("CROSS_SELL");
+        $("#recommendation_read_id").val("");
+        $("#read_result_id").text("");
+        $("#read_result_source_product_id").text("");
+        $("#read_result_recommended_product_id").text("");
+        $("#read_result_recommendation_type").text("");
+        $("#read_result_like_count").text("");
+        $("#read_result_created_at").text("");
+        $("#read_result_updated_at").text("");
         $("#flash_message").text("");
         $("#search_results_body").empty();
     });
@@ -51,6 +59,54 @@ $(function () {
 
         ajax.fail(function (res) {
             $("#flash_message").text(res.responseJSON.message || "Error creating recommendation");
+        });
+    });
+
+    // ****************************************
+    // Read a Recommendation by ID
+    // ****************************************
+    $("#read-btn").click(function () {
+        let rec_id = $("#recommendation_read_id").val();
+
+        // Clear previous results
+        $("#read_result_id").text("");
+        $("#read_result_source_product_id").text("");
+        $("#read_result_recommended_product_id").text("");
+        $("#read_result_recommendation_type").text("");
+        $("#read_result_like_count").text("");
+        $("#read_result_created_at").text("");
+        $("#read_result_updated_at").text("");
+        $("#flash_message").text("");
+
+        if (!rec_id) {
+            $("#flash_message").text("Please enter a Recommendation ID");
+            return;
+        }
+
+        let ajax = $.ajax({
+            type: "GET",
+            url: `/recommendations/${rec_id}`,
+            contentType: "application/json"
+        });
+
+        ajax.done(function (res) {
+            $("#read_result_id").text(res.id);
+            $("#read_result_source_product_id").text(res.source_product_id);
+            $("#read_result_recommended_product_id").text(res.recommended_product_id);
+            $("#read_result_recommendation_type").text(res.recommendation_type);
+            $("#read_result_like_count").text(res.like_count);
+            $("#read_result_created_at").text(res.created_at);
+            $("#read_result_updated_at").text(res.updated_at);
+            $("#flash_message").text("Recommendation retrieved successfully!");
+        });
+
+        ajax.fail(function (res) {
+            if (res.status === 404) {
+                $("#flash_message").text(`Recommendation with id '${rec_id}' was not found.`);
+            } else {
+                let msg = (res.responseJSON && res.responseJSON.message) || "Error reading recommendation";
+                $("#flash_message").text(msg);
+            }
         });
     });
 


### PR DESCRIPTION
Closes #34

## Summary
Adds a Read section to the Recommendations UI so a store manager can look up a recommendation by ID.

## Changes
- `service/static/index.html`: Added a "Read a Recommendation" form with an ID input, a Read button, and a results display showing all fields (ID, Source Product ID, Recommended Product ID, Type, Like Count, Created At, Updated At).
- - `service/static/js/rest_api.js`: Added a `#read-btn` click handler that calls `GET /recommendations/{id}`, populates the result fields on success, and shows a "not found" flash message on 404. Also extended the Clear handler to reset the new Read fields.
- - `features/recommendations.feature`: Added BDD scenarios covering the Read flow end-to-end (successful read after create using copy/paste of the ID, and a 404 not-found scenario).
## Acceptance Criteria
- [x] UI has an input field for recommendation id
- [ ] - [x] Submit calls GET /recommendations/{id}
- [ ] - [x] All fields of the recommendation are displayed
- [ ] - [x] 404 error is shown if id does not exist
- [ ] - [x] BDD scenario covers the Read flow end to end
- [ ] 