### PR TITLE
Create UI for Recommendation - Update (#35)

### DIFF
--- a/features/recommendations.feature
+++ b/features/recommendations.feature
@@ -37,3 +37,27 @@ Feature: Recommendations Service
         When I set the "Read ID" to "999999"
         And I press the "Read" button
         Then I should see the message "was not found"
+
+    Scenario: Update an existing Recommendation's type
+        When I visit the "Home Page"
+        Then I should see "Recommendations" in the title
+        When I set the "Source Product ID" to "30"
+        And I set the "Recommended Product ID" to "40"
+        And I select "Cross Sell" in the "Recommendation Type" dropdown
+        And I press the "Create" button
+        Then I should see the message "Recommendation created successfully!"
+        When I copy the "ID" field
+        And I press the "Clear" button
+        And I paste the "Update ID" field
+        And I select "Up Sell" in the "Update Type" dropdown
+        And I press the "Update" button
+        Then I should see the message "Recommendation updated successfully!"
+
+    Scenario: Update a non-existent Recommendation returns 404
+        When I visit the "Home Page"
+        Then I should see "Recommendations" in the title
+        When I set the "Update ID" to "999999"
+        And I select "Up Sell" in the "Update Type" dropdown
+        And I press the "Update" button
+        Then I should see the message "was not found"
+

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -113,6 +113,57 @@
         </div> <!-- end well -->
       </div> <!-- end Read Form -->
 
+      <!-- UPDATE FORM -->
+      <div class="col-md-12" id="update_form">
+        <h3>Update a Recommendation:</h3>
+        <div class="well">
+          <div class="form-horizontal">
+
+            <!-- UPDATE ID -->
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="recommendation_update_id">ID:</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="recommendation_update_id" placeholder="Enter Recommendation ID">
+              </div>
+            </div>
+
+            <!-- UPDATE RECOMMENDATION TYPE -->
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="recommendation_update_type">Recommendation Type:</label>
+              <div class="col-sm-10">
+                <select class="form-control" id="recommendation_update_type">
+                  <option value="CROSS_SELL" selected>Cross Sell</option>
+                  <option value="UP_SELL">Up Sell</option>
+                  <option value="ACCESSORY">Accessory</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- UPDATE BUTTON -->
+            <div class="form-group">
+              <div class="col-sm-offset-2 col-sm-10">
+                <button type="submit" class="btn btn-warning" id="update-btn">Update</button>
+              </div>
+            </div>
+
+            <!-- UPDATE RESULTS -->
+            <div class="form-group">
+              <label class="control-label col-sm-2">Result:</label>
+              <div class="col-sm-10">
+                <p>ID: <span id="update_result_id"></span></p>
+                <p>Source Product ID: <span id="update_result_source_product_id"></span></p>
+                <p>Recommended Product ID: <span id="update_result_recommended_product_id"></span></p>
+                <p>Recommendation Type: <span id="update_result_recommendation_type"></span></p>
+                <p>Like Count: <span id="update_result_like_count"></span></p>
+                <p>Created At: <span id="update_result_created_at"></span></p>
+                <p>Updated At: <span id="update_result_updated_at"></span></p>
+              </div>
+            </div>
+
+          </div> <!-- form horizontal -->
+        </div> <!-- end well -->
+      </div> <!-- end Update Form -->
+
       <!-- Search Results -->
       <div class="table-responsive col-md-12" id="search_results">
         <table class="table table-striped">

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -18,6 +18,15 @@ $(function () {
         $("#read_result_updated_at").text("");
         $("#flash_message").text("");
         $("#search_results_body").empty();
+        $("#recommendation_update_id").val("");
+        $("#recommendation_update_type").val("CROSS_SELL");
+        $("#update_result_id").text("");
+        $("#update_result_source_product_id").text("");
+        $("#update_result_recommended_product_id").text("");
+        $("#update_result_recommendation_type").text("");
+        $("#update_result_like_count").text("");
+        $("#update_result_created_at").text("");
+        $("#update_result_updated_at").text("");
     });
 
     // ****************************************
@@ -105,6 +114,81 @@ $(function () {
                 $("#flash_message").text(`Recommendation with id '${rec_id}' was not found.`);
             } else {
                 let msg = (res.responseJSON && res.responseJSON.message) || "Error reading recommendation";
+                $("#flash_message").text(msg);
+            }
+        });
+    });
+
+
+    // ****************************************
+    // Update a Recommendation's Type
+    // ****************************************
+    $("#update-btn").click(function () {
+        let rec_id = $("#recommendation_update_id").val();
+        let new_type = $("#recommendation_update_type").val();
+
+        // Clear previous update results
+        $("#update_result_id").text("");
+        $("#update_result_source_product_id").text("");
+        $("#update_result_recommended_product_id").text("");
+        $("#update_result_recommendation_type").text("");
+        $("#update_result_like_count").text("");
+        $("#update_result_created_at").text("");
+        $("#update_result_updated_at").text("");
+        $("#flash_message").text("");
+
+        if (!rec_id) {
+            $("#flash_message").text("Please enter a Recommendation ID");
+            return;
+        }
+
+        // First GET the existing recommendation so we can send a full payload on PUT
+        let getAjax = $.ajax({
+            type: "GET",
+            url: `/recommendations/${rec_id}`,
+            contentType: "application/json"
+        });
+
+        getAjax.done(function (existing) {
+            let data = {
+                "source_product_id": existing.source_product_id,
+                "recommended_product_id": existing.recommended_product_id,
+                "recommendation_type": new_type
+            };
+
+            let putAjax = $.ajax({
+                type: "PUT",
+                url: `/recommendations/${rec_id}`,
+                contentType: "application/json",
+                data: JSON.stringify(data)
+            });
+
+            putAjax.done(function (res) {
+                $("#update_result_id").text(res.id);
+                $("#update_result_source_product_id").text(res.source_product_id);
+                $("#update_result_recommended_product_id").text(res.recommended_product_id);
+                $("#update_result_recommendation_type").text(res.recommendation_type);
+                $("#update_result_like_count").text(res.like_count);
+                $("#update_result_created_at").text(res.created_at);
+                $("#update_result_updated_at").text(res.updated_at);
+                $("#flash_message").text("Recommendation updated successfully!");
+            });
+
+            putAjax.fail(function (res) {
+                if (res.status === 404) {
+                    $("#flash_message").text(`Recommendation with id '${rec_id}' was not found.`);
+                } else {
+                    let msg = (res.responseJSON && res.responseJSON.message) || "Error updating recommendation";
+                    $("#flash_message").text(msg);
+                }
+            });
+        });
+
+        getAjax.fail(function (res) {
+            if (res.status === 404) {
+                $("#flash_message").text(`Recommendation with id '${rec_id}' was not found.`);
+            } else {
+                let msg = (res.responseJSON && res.responseJSON.message) || "Error updating recommendation";
                 $("#flash_message").text(msg);
             }
         });


### PR DESCRIPTION
Closes #35

## Summary
Adds the Update flow to the Recommendations UI so a store manager can change the `recommendation_type` of an existing recommendation.

## Changes
- **`service/static/index.html`** — New "Update a Recommendation" section with an ID input, a Recommendation Type dropdown (Cross Sell / Up Sell / Accessory), an Update button, and a result area that displays the full updated recommendation.
- **`service/static/js/rest_api.js`** — New `#update-btn` click handler. It first GETs `/recommendations/{id}` to fetch the existing record, merges in the selected `recommendation_type`, then issues `PUT /recommendations/{id}`. On success it renders the updated fields and flashes "Recommendation updated successfully!". On 404 (from either GET or PUT) it flashes `Recommendation with id '{id}' was not found.` The Clear handler also resets the new Update fields.
- **`features/recommendations.feature`** — Two new BDD scenarios:
  - *Update an existing Recommendation's type* — creates a recommendation, copies its ID into the Update form, selects a new type, clicks Update, and verifies the success message.
  - *Update a non-existent Recommendation returns 404* — attempts to update id `999999` and verifies the "was not found" flash.

No new step definitions needed — all steps reuse the existing generic steps in `features/steps/web_steps.py` (field IDs follow the `recommendation_<name>` convention and the Update button uses `update-btn`).

## Acceptance Criteria
- [x] UI has fields for id and recommendation_type
- [x] Submit calls PUT /recommendations/{id}
- [x] Updated recommendation is displayed after success
- [x] 404 error is shown if id does not exist
- [x] BDD scenario covers the Update flow end to end
- [x] Selenium steps resolve against existing `web_steps.py`

## Test Plan
Run the BDD suite in CI (or locally with `behave`) against the running Flask app. The two new scenarios should pass alongside the existing Create and Read scenarios.