### PR TITLE
Feature/deploy postgres openshift

### DIFF
--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -30,24 +30,9 @@ spec:
                   key: password
             - name: POSTGRES_DB
               value: recommendations
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            capabilities:
-              drop:
-                - ALL
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data
-              subPath: postgres
-          volumeMounts:
-            - name: postgres-storage
-              mountPath: /var/lib/postgresql/data
-              subPath: postgres
   volumeClaimTemplates:
     - metadata:
         name: postgres-storage

--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -30,6 +30,20 @@ spec:
                   key: password
             - name: POSTGRES_DB
               value: recommendations
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
## Summary
Fixes k8s/postgres/statefulset.yaml to work correctly on OpenShift 
by adding a securityContext and PGDATA environment variable to handle 
OpenShift's strict permission requirements.

## Changes
- Added securityContext with runAsNonRoot and dropped capabilities
- Added PGDATA env var pointing to /var/lib/postgresql/data/pgdata
- Added subPath: postgres to volumeMount

## Verification
- [x] PostgreSQL is running as a StatefulSet in OpenShift
- [x] Database name is set to recommendations
- [x] postgres-creds secret exists with correct credentials
- [x] oc get pods shows postgres-0 as Running
- [x] recommendations database confirmed via psql

Closes #72 