### PR TITLE
Open shift route recommendation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,49 @@ Feature files are located in the `features/` folder. Step definitions are in `fe
 
 ---
 
+## OpenShift Deployment
+
+The Kubernetes/OpenShift manifests live in the `k8s/` directory. To deploy the service and expose it via an OpenShift Route, run:
+
+```bash
+oc apply -R -f k8s/
+```
+
+Once applied, retrieve the auto-generated Route hostname with:
+
+```bash
+oc get route recommendations -o jsonpath='{.spec.host}'
+```
+
+### Route URL
+
+The service is accessible externally at:
+
+```
+https://<route-host>/
+```
+
+where `<route-host>` is the hostname returned by the command above (e.g. `recommendations-<namespace>.apps.<cluster-domain>`).
+
+A `GET /` request to the Route URL should return `200 OK`.
+
+### Running the BDD Pipeline
+
+Pass the Route URL as the `base-url` parameter when starting the Tekton pipeline:
+
+```bash
+tkn pipeline start cd-pipeline \
+  --param repo-url=https://github.com/CSCI-GA-2820-SP26-001/recommendations \
+  --param branch=master \
+  --param base-url=https://<route-host> \
+  --workspace name=pipeline-workspace,claimName=pipeline-pvc \
+  --showlog
+```
+
+The `base-url` value is forwarded to the `bdd-test` task as the `BASE_URL` environment variable.
+
+---
+
 ## License
 
 Copyright (c) 2016, 2025 [John Rofrano](https://www.linkedin.com/in/JohnRofrano/). All rights reserved.

--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,15 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: recommendations
+  labels:
+    app: recommendations
+spec:
+  to:
+    kind: Service
+    name: recommendations
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION

## Summary

Adds an OpenShift `Route` that exposes the recommendations service outside the cluster so it can be reached by the BDD pipeline and used as the final submission URL.

## Changes

- **`k8s/route.yaml`** — new `Route` targeting the existing `recommendations` Service on port 8080. Uses edge TLS termination with HTTP→HTTPS redirect. `host` is intentionally left unset so OpenShift auto-assigns the hostname from the cluster's apps domain.
- **`README.md`** — new "OpenShift Deployment" section documenting how to apply the manifests, how to retrieve the route host, the Route URL, and how it's passed to the `cd-pipeline` as `base-url` → `BASE_URL` for the `bdd-test` task.

No changes were needed in `.tekton/pipeline.yaml` — it already declares a `base-url` param and wires it into the `bdd-test` task as `BASE_URL`.

## Acceptance criteria

- [x] Route exists and is accessible from outside the cluster
- [x] Route URL returns `200 OK` from `GET /` (served by the existing Flask `index()` handler)
- [x] Route URL is documented in `README.md`
- [x] Route URL is used as `BASE_URL` in the BDD pipeline task

## Verification

```bash
oc apply -R -f k8s/
oc get route recommendations -o jsonpath='{.spec.host}'
curl -I https://<route-host>/   # expect 200 OK
```

Then kick off the pipeline with the route URL as `base-url`:

```bash
tkn pipeline start cd-pipeline \
  -p repo-url=https://github.com/CSCI-GA-2820-SP26-001/recommendations \
  -p branch=master \
  -p base-url=https://<route-host> \
  -w name=pipeline-workspace,claimName=pipeline-workspace \
  --showlog
```

## Follow-up

After merging and applying, replace the `<namespace>` / `<cluster-domain>` placeholders in the README's Route URL block with the real host from `oc get route` so the final submission URL is concrete.