### PR TITLE
Add test task to Tekton pipeline that runs make test

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -38,9 +38,10 @@ spec:
       script: |
         #!/bin/bash
         set -e
+        apt-get update --quiet && apt-get install -y make --quiet
         pip install pipenv --quiet
         pipenv install --system --dev --quiet
-        pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
+        make test
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task


### PR DESCRIPTION
Add Test Task to Tekton Pipeline
Closes #76
What was changed
Updated .tekton/tasks.yaml to add a custom test Task that runs make test as part of the CI/CD pipeline.
How it works

The test task installs make via apt-get, installs Python dependencies via pipenv, then runs make test
make test invokes pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
The task runs in parallel with the lint task — both tasks have runAfter: [clone] in pipeline.yaml, so they start simultaneously after the clone step
The pipeline fails automatically if any unit tests fail (set -e + pytest non-zero exit)
The pipeline fails automatically if code coverage drops below 95% (--cov-fail-under=95)
The task uses the shared pipeline-workspace from the clone task, mounted as the source workspace
The DATABASE_URI is injected securely from the postgres-creds Kubernetes secret