### PR TITLE
Add git-clone task from Tekton Hub to pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -19,8 +19,12 @@ spec:
   tasks:
     - name: clone
       taskRef:
-        name: git-clone
-        kind: ClusterTask
+        resolver: hub
+        params:
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.9"
       workspaces:
         - name: output
           workspace: pipeline-workspace


### PR DESCRIPTION
Closes #74

## Changes
Updated `.tekton/pipeline.yaml` to reference the `git-clone` task from Tekton Hub using a resolver, replacing the previous `ClusterTask` reference.

The clone task remains first in the pipeline and clones the master branch into the shared workspace before any other tasks run.