### PR TITLE
Add deploy task to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -64,7 +64,7 @@ spec:
       params:
         - name: IMAGE
           value: default-route-openshift-image-registry.apps.rm3.7wse.p1.openshiftapps.com/tmf8970-dev/recommendations:latest
-
+    # Applies Kubernetes manifests to the OpenShift cluster
     - name: deploy
       taskRef:
         name: openshift-client


### PR DESCRIPTION
Closes #78

## Changes
The deploy task was already present in `.tekton/pipeline.yaml` from prior 
pipeline work, satisfying all acceptance criteria:
- Runs after the build task
- Applies all manifests from the k8s/ folder using `kubectl apply -R -f k8s/`
- Uses the openshift-client ClusterTask which fails the pipeline if deployment fails

Added a comment to document the task's purpose.